### PR TITLE
div:contenteditable update range for everytime focus event is triggered

### DIFF
--- a/wdt-emoji-bundle.js
+++ b/wdt-emoji-bundle.js
@@ -653,7 +653,7 @@
       var s = window.getSelection();
       if (!wdtEmojiBundle.ranges[this.dataset.rangeIndex]) {
         wdtEmojiBundle.ranges[this.dataset.rangeIndex] = new Range();
-      } else if (s.rangeCount > 0) {
+      } else {
         s.removeAllRanges();
         s.addRange(wdtEmojiBundle.ranges[this.dataset.rangeIndex]);
       }


### PR DESCRIPTION
In Safari, when `focus` event is triggered, `window.getSelection()` take no range, `window.r
angeCount = 0`, then it can not update range.
```
el.addEventListener('focus', function () {
      var s = window.getSelection();
      if (!wdtEmojiBundle.ranges[this.dataset.rangeIndex]) {
        wdtEmojiBundle.ranges[this.dataset.rangeIndex] = new Range();
      } else if (s.rangeCount > 0) {
        s.removeAllRanges();
        s.addRange(wdtEmojiBundle.ranges[this.dataset.rangeIndex]);
      }
    });
```
Then it should be removed `if (s.rangeCount > 0)`
