### PR TITLE
Fix BUG: restore selection in div:contentedittable does not work on iOS safari 10.2 and later

### DIFF
--- a/wdt-emoji-bundle.js
+++ b/wdt-emoji-bundle.js
@@ -659,7 +659,7 @@
       }
     });
 
-    addListenerMulti(el, 'focus mouseup keyup input', function () {
+    addListenerMulti(el, 'focus mouseup keyup input blur', function () {
       wdtEmojiBundle.ranges[this.dataset.rangeIndex] = window.getSelection().getRangeAt(0);
     });
 


### PR DESCRIPTION
ref https://github.com/g-viet/til/issues/10